### PR TITLE
Update the downloader to match the current version of GameServer

### DIFF
--- a/SandboxDownloader-v2/Program.cs
+++ b/SandboxDownloader-v2/Program.cs
@@ -122,7 +122,7 @@ namespace AutoCompilerForGameServer
 
                 Console.WriteLine($"New Commit: {newUpdate}");
 
-                needsCompiled = true; // !lastUpdate.Equals(newUpdate);
+                needsCompiled = !lastUpdate.Equals(newUpdate);
             }
             else
             {
@@ -262,25 +262,25 @@ namespace AutoCompilerForGameServer
             nugetProcess.BeginErrorReadLine();
             nugetProcess.WaitForExit();
 
-            Console.Write("Running MSBuild... ");
+            Console.Write("Running dotnet... ");
             var slnPath = Path.Combine(path, "GameServer.sln");
-            var msbuildProcess = new Process
+            var buildProcess = new Process
             {
-                StartInfo = new ProcessStartInfo("MSBuild.exe")
-                {// /t:Build,AfterBuild
-                    Arguments = $"\"{slnPath}\" /verbosity:minimal /property:Configuration={_configurationMode}",
+                StartInfo = new ProcessStartInfo("cmd.exe")
+                {
+                    Arguments = $"/c dotnet build \"{slnPath}\" --configuration Release",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true
                 }
             };
-            msbuildProcess.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
-            msbuildProcess.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
-            msbuildProcess.Start();
-            msbuildProcess.BeginOutputReadLine();
-            msbuildProcess.BeginErrorReadLine();
-            msbuildProcess.WaitForExit();
+            buildProcess.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
+            buildProcess.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
+            buildProcess.Start();
+            buildProcess.BeginOutputReadLine();
+            buildProcess.BeginErrorReadLine();
+            buildProcess.WaitForExit();
 
             logicDurationWatch.Stop();
             var timeElapsed = logicDurationWatch.ElapsedMilliseconds;

--- a/SandboxDownloader-v2/Program.cs
+++ b/SandboxDownloader-v2/Program.cs
@@ -226,42 +226,6 @@ namespace AutoCompilerForGameServer
             var path = Path.Combine(_executingDirectory, _gameServerSourceFileName);//, "CurrentRepository");
             Console.WriteLine($"Game server path: {path}");
 
-            Console.Write("Restoring nuget packages... ");
-            
-            var nugetProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo("NuGet.exe", $"restore \"{path}\"")
-                {
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                }
-            };
-            nugetProcess.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
-            nugetProcess.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
-            nugetProcess.Start();
-            nugetProcess.BeginOutputReadLine();
-            nugetProcess.BeginErrorReadLine();
-            nugetProcess.WaitForExit();
-
-            nugetProcess = new Process
-            {
-                StartInfo = new ProcessStartInfo("NuGet.exe", $"update")
-                {
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                }
-            };
-            nugetProcess.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
-            nugetProcess.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
-            nugetProcess.Start();
-            nugetProcess.BeginOutputReadLine();
-            nugetProcess.BeginErrorReadLine();
-            nugetProcess.WaitForExit();
-
             Console.Write("Running dotnet... ");
             var slnPath = Path.Combine(path, "GameServer.sln");
             var buildProcess = new Process

--- a/SandboxDownloader-v2/SandboxDownloader-v2.csproj
+++ b/SandboxDownloader-v2/SandboxDownloader-v2.csproj
@@ -38,14 +38,12 @@
   <ItemGroup>
     <Reference Include="LibGit2Sharp, Version=0.22.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <HintPath>..\packages\LibGit2Sharp.0.22.0\lib\net40\LibGit2Sharp.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.2\System.dll</HintPath>

--- a/SandboxDownloader-v2/packages.config
+++ b/SandboxDownloader-v2/packages.config
@@ -3,5 +3,5 @@
   <package id="LibGit2Sharp" version="0.22.0" targetFramework="net452" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.129" targetFramework="net452" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
* Replaced MSBuild by dotne command
* Removed NuGet restore things as it is done automatically with `dotnet build`
* Updated NuGet packages versions to match the new one
* Removed the copy-paste of settings as it is not needed with the new GameServer version